### PR TITLE
Adds `exome` to state managers

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -75,6 +75,7 @@ State managers combine observable state with actions and framework bindings, int
 - [storeon](https://github.com/storeon/storeon) - Minimal 400-byte redux-styled store. (p)react, has third-party connectors.
 - [unistore](https://github.com/developit/unistore) - Sub-1 kB store with actions from preact developers, (p)react support.
 - [teaful](https://github.com/teafuljs/teaful) - (p)react store with useState-like API in 1 kB.
+- [exome](https://github.com/marcisbee/exome) - Sub-1 kB atomic store with lots of framework connectors.
 
 ## Routers and URL Utils
 


### PR DESCRIPTION
- [x] Size is under 2Kb-ish, min + gzip, with all deps, except for special categories.
  - **Core: [1.41KB -> 810B (gzip)](https://deno.bundlejs.com/?q=exome&badge=);**
  - **With react connector: [1.6KB -> 914B (gzip)](https://deno.bundlejs.com/?q=exome,exome/react&treeshake=[*],[{+useStore+}]&config={%22esbuild%22:{%22external%22:[%22react%22]}}&badge=).**
- [x] For tree-shakable libraries, the size of a useful subset must be under 2Kb-ish.
  - **_same same._**
- [x] Second-level libraries only allowed for React, Vue, Angular, svelte. The size of the framework is excluded from the size limit.
  - **It supports React, Preact, Vue, Svelte, Lit, Rxjs, Angular and vanilla integrations.**
- [x] Useful client-side — no node.js exclusive libraries and dev / build tooling.
  - **It works both in browser, node and even deno.**
- [x] 100+ GitHub stars or 100+ weekly npm installs for the last 4 weeks.
  - **As of now 120 stars on GitHub.**
- [x] The library must contain some JS.
  - **Written in TS, published to npm as JS.**
- [x] Check if the library is not already in [WIP.](https://github.com/thoughtspile/awesome-tiny-js/blob/main/WIP.md)
  - **Don't see it.** 🤷